### PR TITLE
Add remote_ip to handler logs

### DIFF
--- a/hack/openshift/template.yaml
+++ b/hack/openshift/template.yaml
@@ -27,7 +27,7 @@ objects:
           args:
           - --server.listen-address=0.0.0.0
           - --server.listen-port=10051
-          - --server.ip-whitelist="${ZI_SERVER_IP_WHITELIST}"
+          - --server.ip-whitelist=${ZI_SERVER_IP_WHITELIST}
           - --metrics.listen-address=0.0.0.0
           - --metrics.listen-port=2112
           - --metrics.file=/etc/zabbix-impersonator/metrics.json


### PR DESCRIPTION
A `remote_ip` field will not be logged for all log warnings and errors from handling client connections

This also fixes a quoting problem in the openshift template