### PR TITLE
use ioutil.ReadAll to read connection data

### DIFF
--- a/zserver.go
+++ b/zserver.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -228,10 +227,7 @@ func (s *ZServer) handleRequest(conn net.Conn) {
 		return
 	}
 
-	bodySize := binary.LittleEndian.Uint64(respHeader[5:])
-
-	respBody := make([]byte, bodySize)
-	_, err = conn.Read(respBody)
+	body, err := ioutil.ReadAll(conn)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"remote_ip": ip,
@@ -241,7 +237,7 @@ func (s *ZServer) handleRequest(conn net.Conn) {
 	}
 
 	var request Request
-	err = json.Unmarshal(respBody, &request)
+	err = json.Unmarshal(body, &request)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"remote_ip": ip,


### PR DESCRIPTION
This fixes a bug where the client was unable to read what appears to be chunked data, occuring when large datasets were sent